### PR TITLE
🐛 fix: filter 의 scroll lock 및 position, z-index 버그 해결

### DIFF
--- a/src/components/Filter/sub-components/Base.tsx
+++ b/src/components/Filter/sub-components/Base.tsx
@@ -33,7 +33,11 @@ const FilterActiveControlInput = styled.input`
   pointer-events: none;
 `
 
-const FilterBase = ({ children, active, setActive }: {
+const FilterBase = ({
+  children,
+  active,
+  setActive,
+}: {
   children: Array<ReactElement | string>
   active: boolean
   setActive: Dispatch<SetStateAction<boolean>>
@@ -43,14 +47,18 @@ const FilterBase = ({ children, active, setActive }: {
   // filter active 시 스크롤 disable
   useEffect(() => {
     const body = document.body
+    const html = document.documentElement
     if (active) {
       body.setAttribute("style", "overflow:hidden;")
+      html.setAttribute("style", "overflow:hidden;")
     } else {
       body.setAttribute("style", "")
+      html.setAttribute("style", "")
     }
     // unmounted 시 초기화
     return () => {
       body.setAttribute("style", "")
+      html.setAttribute("style", "")
     }
   }, [active])
 
@@ -67,7 +75,7 @@ const FilterBase = ({ children, active, setActive }: {
         onMouseDown={() =>
           // blur 이벤트 순서 이슈로 timeout 추가
           setTimeout(() => {
-            !active && setActive(true)
+            if (!active) setActive(true)
           })
         }
       >


### PR DESCRIPTION
filter component 의 scroll lock, position, z-index 문제를 해결했습니다
- scroll lock 이 기존 body 에만 추가 되던걸 html 까지 추가 되도록 했습니다.
- fixed 의 부모 가 gpu 를 사용하는 css 를 가지고 있을 경우 position 값의 대상이 viewport 에서 부모로 옮겨가는 문제로 portal 을 이용했습니다. 비활성화 시 html 트리에서 제거하는것은 따로 추가하지 않았으니 필요시 말씀 해주시기 바랍니다.